### PR TITLE
New crypto.uniform_01() function samples uniformly from [0,1].

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,9 @@ Returns a nacl.sign keypair object:
 <dd><p>Sample uniformly at random from nonnegative integers below a
 specified bound.</p>
 </dd>
+<dt><a href="#uniform_01">uniform_01()</a> ⇒ <code>number</code></dt>
+<dd><p>Sample uniformly at random from floating-point numbers in [0, 1].</p>
+</dd>
 </dl>
 
 <a name="passphrase"></a>
@@ -199,3 +202,9 @@ specified bound.
 | --- | --- | --- |
 | n | <code>number</code> | exclusive upper bound, positive integer at most 2^53 |
 
+<a name="uniform_01"></a>
+
+## uniform_01() ⇒ <code>number</code>
+Sample uniformly at random from floating-point numbers in [0, 1].
+
+**Kind**: global function  


### PR DESCRIPTION
Typical Math.random() implementations are nonuniform, e.g. they round results <2^-53 or <2^-64 to 0.  The width of the interval of real numbers in [0,1] rounded to 0 is less than 2^-1000, so in practical terms 0 should be impossible, but the Bitcoin network today guesses something with probability 2^-64 of success every second or so, so 2^-64 is small but definitely not negligible.

Math.random() also _excludes_ 1, but the width of the interval of real numbers in [0,1] that are rounded to 1 is (maybe a fencepost away from) 2^-53, unimaginably larger than the width of the interval of real numbers that are rounded to 0.  This function does not exclude 1, which means Math.floor(crypto.uniform_01() * n) is not guaranteed to be below n, but you should use crypto.uniform(n) for that anyway.