### PR TITLE
Tidy up random API.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,9 @@
 <dt><a href="#passphrase">passphrase</a></dt>
 <dd><p>Utilities for converting keys to passphrases using bip39 or niceware</p>
 </dd>
+<dt><a href="#random">random</a></dt>
+<dd><p>Random samplers.</p>
+</dd>
 </dl>
 
 ## Constants
@@ -36,13 +39,6 @@ Returns a nacl.sign keypair object:
 </dd>
 <dt><a href="#hexToUint8">hexToUint8([hex])</a> ⇒ <code>Uint8Array</code></dt>
 <dd><p>Converts hex string to a Uint8Array.</p>
-</dd>
-<dt><a href="#uniform">uniform(n)</a> ⇒ <code>number</code></dt>
-<dd><p>Sample uniformly at random from nonnegative integers below a
-specified bound.</p>
-</dd>
-<dt><a href="#uniform_01">uniform_01()</a> ⇒ <code>number</code></dt>
-<dd><p>Sample uniformly at random from floating-point numbers in [0, 1].</p>
 </dd>
 </dl>
 
@@ -110,6 +106,35 @@ passphrase is bip39 or niceware based on length.
 | --- | --- | --- |
 | passphrase | <code>string</code> | bip39/niceware phrase to convert |
 
+<a name="random"></a>
+
+## random
+Random samplers.
+
+**Kind**: global variable  
+
+* [random](#random)
+    * [.uniform(n)](#random.uniform) ⇒ <code>number</code>
+    * [.uniform_01()](#random.uniform_01) ⇒ <code>number</code>
+
+<a name="random.uniform"></a>
+
+### random.uniform(n) ⇒ <code>number</code>
+Sample uniformly at random from nonnegative integers below a
+specified bound.
+
+**Kind**: static method of [<code>random</code>](#random)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| n | <code>number</code> | exclusive upper bound, positive integer at most 2^53 |
+
+<a name="random.uniform_01"></a>
+
+### random.uniform_01() ⇒ <code>number</code>
+Sample uniformly at random from floating-point numbers in [0, 1].
+
+**Kind**: static method of [<code>random</code>](#random)  
 <a name="DEFAULT_SEED_SIZE"></a>
 
 ## DEFAULT_SEED_SIZE : <code>number</code>
@@ -190,21 +215,3 @@ Converts hex string to a Uint8Array.
 | --- | --- | --- |
 | [hex] | <code>string</code> | Hex string to convert; defaults to '' |
 
-<a name="uniform"></a>
-
-## uniform(n) ⇒ <code>number</code>
-Sample uniformly at random from nonnegative integers below a
-specified bound.
-
-**Kind**: global function  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| n | <code>number</code> | exclusive upper bound, positive integer at most 2^53 |
-
-<a name="uniform_01"></a>
-
-## uniform_01() ⇒ <code>number</code>
-Sample uniformly at random from floating-point numbers in [0, 1].
-
-**Kind**: global function  

--- a/index.js
+++ b/index.js
@@ -257,67 +257,74 @@ module.exports.passphrase = {
 }
 
 /**
- * Sample uniformly at random from nonnegative integers below a
- * specified bound.
- *
- * @param {number} n - exclusive upper bound, positive integer at most 2^53
- * @returns {number}
+ * Random samplers.
  */
-module.exports.uniform = function (n/* : number */) {
-  if (typeof n !== 'number' || n % 1 !== 0 || n <= 0 || n > Math.pow(2, 53)) {
-    throw new Error('Bound must be positive integer at most 2^53.')
-  }
-  const min = Math.pow(2, 53) % n
-  let x
-  do {
-    const b = nacl.randomBytes(7)
-    const l32 = b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)
-    const h21 = b[4] | (b[5] << 8) | ((b[6] & 0x1f) << 16)
-    x = Math.pow(2, 32) * h21 + l32
-  } while (x < min)
-  return x % n
-}
-
-/**
- * Sample uniformly at random from floating-point numbers in [0, 1].
- *
- * @returns {number}
- */
-module.exports.uniform_01 = function () {
-  function uniform32 () {
-    const b = nacl.randomBytes(4)
-    return (b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)) >>> 0
-  }
-
-  // Draw an exponent with geometric distribution.
-  let e = 0
-  let x
-  // One in four billion chance that uniform32() is zero.
-  /* istanbul ignore if */
-  if ((x = uniform32()) === 0) {
+module.exports.random = {
+  /**
+   * Sample uniformly at random from nonnegative integers below a
+   * specified bound.
+   *
+   * @method
+   * @param {number} n - exclusive upper bound, positive integer at most 2^53
+   * @returns {number}
+   */
+  uniform: function (n/* : number */) {
+    if (typeof n !== 'number' || n % 1 !== 0 || n <= 0 || n > Math.pow(2, 53)) {
+      throw new Error('Bound must be positive integer at most 2^53.')
+    }
+    const min = Math.pow(2, 53) % n
+    let x
     do {
-      // emin = -1022; emin - 53 = -1054; emin - 64 = -1088 provides a
-      // hedge of paranoia in case I made a fencepost here.
-      /* istanbul ignore if */
-      if (e >= 1088) {
-        // You're struck by lightning, and you win the lottery...
-        // or your PRNG is broken.
-        return 0
-      }
-      e += 32
-    } while ((x = uniform32()) === 0)
+      const b = nacl.randomBytes(7)
+      const l32 = b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)
+      const h21 = b[4] | (b[5] << 8) | ((b[6] & 0x1f) << 16)
+      x = Math.pow(2, 32) * h21 + l32
+    } while (x < min)
+    return x % n
+  },
+
+  /**
+   * Sample uniformly at random from floating-point numbers in [0, 1].
+   *
+   * @method
+   * @returns {number}
+   */
+  uniform_01: function () {
+    function uniform32 () {
+      const b = nacl.randomBytes(4)
+      return (b[0] | (b[1] << 8) | (b[2] << 16) | (b[3] << 24)) >>> 0
+    }
+
+    // Draw an exponent with geometric distribution.
+    let e = 0
+    let x
+    // One in four billion chance that uniform32() is zero.
+    /* istanbul ignore if */
+    if ((x = uniform32()) === 0) {
+      do {
+        // emin = -1022; emin - 53 = -1054; emin - 64 = -1088 provides a
+        // hedge of paranoia in case I made a fencepost here.
+        /* istanbul ignore if */
+        if (e >= 1088) {
+          // You're struck by lightning, and you win the lottery...
+          // or your PRNG is broken.
+          return 0
+        }
+        e += 32
+      } while ((x = uniform32()) === 0)
+    }
+    e += Math.clz32(x)
+
+    // Draw normal odd 64-bit significand with uniform distribution.
+    const hi = (uniform32() | 0x80000000) >>> 0
+    const lo = (uniform32() | 0x00000001) >>> 0
+
+    // Assemble parts into [2^63, 2^64] with uniform distribution.
+    // Using an odd low part breaks ties in the rounding, which should
+    // occur only in a set of measure zero.
+    const s = hi * Math.pow(2, 32) + lo
+
+    // Scale into [1/2, 1] and apply the exponent.
+    return s * Math.pow(2, (-64 - e))
   }
-  e += Math.clz32(x)
-
-  // Draw normal odd 64-bit significand with uniform distribution.
-  const hi = (uniform32() | 0x80000000) >>> 0
-  const lo = (uniform32() | 0x00000001) >>> 0
-
-  // Assemble parts into [2^63, 2^64] with uniform distribution.
-  // Using an odd low part breaks ties in the rounding, which should
-  // occur only in a set of measure zero.
-  const s = hi * Math.pow(2, 32) + lo
-
-  // Scale into [1/2, 1] and apply the exponent.
-  return s * Math.pow(2, (-64 - e))
 }

--- a/random-lib.js
+++ b/random-lib.js
@@ -1,0 +1,25 @@
+const crypto = require('./index')
+
+/**
+ * Sample uniformly at random from integers {min, min+1, ..., max-1}.
+ * API compatible with npm random-lib 2.1.0.
+ *
+ * @param {object} opts - options
+ * @param {number} opts.min - inclusive lower bound on result
+ * @param {number} opts.max - exclusive upper bound on result
+ * @returns {number}
+ */
+module.exports.randomInt = function (opts) {
+  const min = opts.min || 0 // inclusive
+  const max = opts.max // exclusive
+  const uniform = opts.uniform || crypto.random.uniform // for testing only
+  if (typeof min !== 'number' || min % 1 !== 0 || min < -Math.pow(2, 53) ||
+      typeof max !== 'number' || max % 1 !== 0 || max > Math.pow(2, 53) ||
+      min >= max) {
+    throw new Error('Bounds must be ascending integers from -2^53 to 2^53.')
+  }
+  if (max - (min + 1) >= Math.pow(2, 53)) {
+    throw new Error('Bounds must not differ by more than 2^53.')
+  }
+  return min + uniform(max - min)
+}

--- a/test/randomLibTest.js
+++ b/test/randomLibTest.js
@@ -1,0 +1,71 @@
+const random = require('../random-lib')
+const test = require('tape')
+
+const ERRPAT0 = /integers from -2\^53 to 2\^53/
+const ERRPAT1 = /Bounds must be ascending/
+const ERRPAT2 = /Bounds must not differ by more than 2\^53/
+
+test('randomInt with missing max throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: 123}), ERRPAT0)
+})
+
+test('randomInt with fractional min throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: 1.5, max: 123}), ERRPAT0)
+})
+
+test('randomInt with fractional max throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: 1, max: 123.5}), ERRPAT0)
+})
+
+test('randomInt with excessive min throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: -(2 ** 53) - 2, max: 123}), ERRPAT0)
+})
+
+test('randomInt with excessive max throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: 1, max: 2 ** 53 + 2}), ERRPAT0)
+})
+
+test('randomInt with disordered min/max throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: 2, max: 1}), ERRPAT1)
+})
+
+test('randomInt with equal min/max throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: 2, max: 2}), ERRPAT1)
+})
+
+// We could do this, but it would require extra work, and nobody cares.
+test('randomInt with excessively distant min/max throws #1', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: -1, max: 2 ** 53}), ERRPAT2)
+})
+
+test('randomInt with excessively distant min/max throws #2', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: -(2 ** 53), max: 2 ** 53}), ERRPAT2)
+})
+
+test('randomInt with excessively distant min/max throws', t => {
+  t.plan(1)
+  t.throws(() => random.randomInt({min: -(2 ** 53), max: 2 ** 53}), ERRPAT2)
+})
+
+test(`randomInt defaults to min=0`, t => {
+  t.plan(1)
+  t.equal(27, random.randomInt({max: 32, uniform: n => 27}))
+})
+
+for (let i = 0; i < 3; i++) {
+  const min = 42
+  const max = 45
+  test(`randomInt({min: ${min}, max: ${max}}) [${i}] gives ${i + min}`, t => {
+    t.plan(1)
+    t.equal(i + min, random.randomInt({min: min, max: max, uniform: n => i}))
+  })
+}

--- a/test/randomTest.js
+++ b/test/randomTest.js
@@ -144,53 +144,53 @@ const ERRPAT = /Bound must be positive integer at most 2\^53\./
 
 test('uniform() throws', (t) => {
   t.plan(1)
-  t.throws(() => crypto.uniform(), ERRPAT)
+  t.throws(() => crypto.random.uniform(), ERRPAT)
 })
 
 test("uniform('foo') throws", (t) => {
   t.plan(1)
-  t.throws(() => crypto.uniform('foo'), ERRPAT)
+  t.throws(() => crypto.random.uniform('foo'), ERRPAT)
 })
 
 test('uniform(0) throws', (t) => {
   t.plan(1)
-  t.throws(() => crypto.uniform(0), ERRPAT)
+  t.throws(() => crypto.random.uniform(0), ERRPAT)
 })
 
 test('uniform(0.5) throws', (t) => {
   t.plan(1)
-  t.throws(() => crypto.uniform(0.5), ERRPAT)
+  t.throws(() => crypto.random.uniform(0.5), ERRPAT)
 })
 
 // round(2**53 + 1) = 2**53, but round(2**53 + 2) > 2**53
 test('uniform(2**53 + 2) throws', (t) => {
   t.plan(1)
-  t.throws(() => crypto.uniform((2 ** 53) + 2), ERRPAT)
+  t.throws(() => crypto.random.uniform((2 ** 53) + 2), ERRPAT)
 })
 
 test('uniform(1) yields 0', (t) => {
   t.plan(1)
-  t.equal(0, crypto.uniform(1))
+  t.equal(0, crypto.random.uniform(1))
 })
 
 test('uniform(2**53) does not throw', (t) => {
   t.plan(1)
-  t.doesNotThrow(() => crypto.uniform(2 ** 53))
+  t.doesNotThrow(() => crypto.random.uniform(2 ** 53))
 })
 
 test('uniform(DF) passes psi test for uniform distribution', (t) => {
-  psiTest(t, i => 1 / DF, () => crypto.uniform(DF))
+  psiTest(t, i => 1 / DF, () => crypto.random.uniform(DF))
 })
 
 // Empirically confirm that the psi test has enough statistical power
 // to detect modulo bias in the above test.
 test('uniform(2*DF + 1) % DF fails psi test for uniform distribution', (t) => {
-  psiTestReject(t, i => 1 / DF, () => crypto.uniform((2 * DF) + 1) % DF)
+  psiTestReject(t, i => 1 / DF, () => crypto.random.uniform((2 * DF) + 1) % DF)
 })
 
 test('uniform(256) % DF passes psi test for modulo bias', (t) => {
   psiTest(t, i => (Math.floor(256 / DF) + (i < 256 % DF)) / 256, () => {
-    return crypto.uniform(256) % DF
+    return crypto.random.uniform(256) % DF
   })
 })
 
@@ -209,14 +209,15 @@ test('bits [24..32) of bad uniform fail psi test for uniform distribution', (t) 
 for (let b = 0; b < 53 - 8; b += 8) {
   test(`bits [${b}..${b + 8}) of uniform(2**53) pass psi test for uniform distribution`, (t) => {
     psiTest(t, i => (Math.floor(256 / DF) + (i < 256 % DF)) / 256, () => {
-      return (0xff & Math.floor(crypto.uniform(2 ** 53) / (2 ** b))) % DF
+      const x = crypto.random.uniform(2 ** 53)
+      return (0xff & Math.floor(x / (2 ** b))) % DF
     })
   })
 }
 
 test(`bits [45..53) of uniform(2**53) pass psi test for uniform distribution`, (t) => {
   psiTest(t, i => (Math.floor(256 / DF) + (i < 256 % DF)) / 256, () => {
-    return (0xff & Math.floor(crypto.uniform(2 ** 53) / (2 ** 45))) % DF
+    return (0xff & Math.floor(crypto.random.uniform(2 ** 53) / (2 ** 45))) % DF
   })
 })
 
@@ -248,7 +249,7 @@ function uniform_01_lowprec () { // eslint-disable-line camelcase
 // used the naive approach for sampling IEEE 754-2008 binary16 numbers
 // in [0,1] that many people use for binary64 numbers.
 function baduniform_01_lowprec () { // eslint-disable-line camelcase
-  return crypto.uniform(2 ** 11) / (2 ** 11)
+  return crypto.random.uniform(2 ** 11) / (2 ** 11)
 }
 
 // Like uniform_01, but with a bug: wrong shift amount.
@@ -293,7 +294,7 @@ function reject (x0, f) {
 // It had better appear uniformly distributed to psi.
 test('uniform_01() passes psi test for uniformly spaced buckets', (t) => {
   psiTest(t, i => 1 / DF, () => {
-    return Math.floor(reject(1, crypto.uniform_01) * DF)
+    return Math.floor(reject(1, crypto.random.uniform_01) * DF)
   })
 })
 
@@ -315,7 +316,7 @@ test('baduniform_01_lowprec() fails psi test for uniformly spaced buckets', (t) 
 // should continue to pass psi.
 test('(uniform_01()*64)%1 passes psi test for uniformly spaced buckets', (t) => {
   psiTest(t, i => 1 / DF, () => {
-    return Math.floor(((reject(1, crypto.uniform_01) * 64) % 1) * DF)
+    return Math.floor(((reject(1, crypto.random.uniform_01) * 64) % 1) * DF)
   })
 })
 


### PR DESCRIPTION
- Gather random samplers under `crypto.random.*` to make them greppable.
- Add thin wrapper for `randomInt` in random-lib 2.1.0 to make migration of our existing repositories easier.