### PR TITLE
feat(types): introduce type files for projects using TS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ jspm_packages
 testbundle.js
 browser/*.js
 yarn.lock
+
+# Generates by typescript
+*.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brave-crypto",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brave-crypto",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MPL-2.0",
       "dependencies": {
         "bip39": "^2.6.0",
@@ -14,10 +14,12 @@
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
+        "@types/node": "^20.14.8",
         "browserify": "16.5.2",
         "jsdoc-to-markdown": "7.1.1",
         "standard": "16.0.4",
-        "tape": "4.17.0"
+        "tape": "4.17.0",
+        "typescript": "^5.5.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -303,6 +305,15 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
       "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -5256,6 +5267,19 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
+    "node_modules/typescript": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
@@ -5325,6 +5349,12 @@
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "node_modules/unorm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,12 @@
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
-        "@types/node": "^20.14.8",
+        "@types/node": "20.14.8",
         "browserify": "16.5.2",
         "jsdoc-to-markdown": "7.1.1",
         "standard": "16.0.4",
         "tape": "4.17.0",
-        "typescript": "^5.5.2"
+        "typescript": "5.5.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-crypto",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Crypto utils for Brave Browser",
   "keywords": [
     "nacl",
@@ -14,17 +14,20 @@
   "homepage": "http://www.github.com/brave/crypto",
   "main": "index.js",
   "devDependencies": {
+    "@types/node": "^20.14.8",
     "browserify": "16.5.2",
     "jsdoc-to-markdown": "7.1.1",
     "standard": "16.0.4",
-    "tape": "4.17.0"
+    "tape": "4.17.0",
+    "typescript": "^5.5.2"
   },
   "scripts": {
-    "build": "browserify ./index.js -o browser/crypto.js",
+    "build": "tsc && browserify index.js -o browser/crypto.js",
     "lint": "standard",
     "lint-fix": "standard --fix",
     "jsdoc": "jsdoc2md index.js > docs/api.md",
-    "test": "tape test/**/*.js"
+    "test": "tape test/**/*.js",
+    "compile": "tsc"
   },
   "standard": {
     "ignore": [
@@ -45,5 +48,6 @@
   "resolutions": {
     "hosted-git-info": "3.0.8",
     "underscore": "1.12.1"
-  }
+  },
+  "types": "index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "homepage": "http://www.github.com/brave/crypto",
   "main": "index.js",
   "devDependencies": {
-    "@types/node": "^20.14.8",
+    "@types/node": "20.14.8",
     "browserify": "16.5.2",
     "jsdoc-to-markdown": "7.1.1",
     "standard": "16.0.4",
     "tape": "4.17.0",
-    "typescript": "^5.5.2"
+    "typescript": "5.5.2"
   },
   "scripts": {
     "build": "tsc && browserify index.js -o browser/crypto.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES6",
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+  },
+  "include": ["*.js", "**/*.ts"],
+}


### PR DESCRIPTION
Adds typings into the base directory, so that a TS project can understand what it is importing

Generates `index.d.ts`:
```ts
export const DEFAULT_SEED_SIZE: number;
export function hmac(message: Uint8Array, key: Uint8Array): Uint8Array;
export function getHKDF(ikm: Uint8Array, info: Uint8Array, extractLen: number, salt?: Uint8Array | undefined): Uint8Array;
export function getSeed(size?: number | undefined): Uint8Array;
export function deriveSigningKeysFromSeed(seed: Uint8Array, salt?: Uint8Array | undefined): {
    secretKey: Uint8Array;
    publicKey: Uint8Array;
};
export function uint8ToHex(arr: Uint8Array | Buffer): string;
export function hexToUint8(hex?: string | undefined): Uint8Array;
export namespace passphrase {
    function fromBytesOrHex(bytes: Uint8Array | Buffer | string, useNiceware?: boolean | undefined): string;
    function toBytes32(passphrase: string): Uint8Array;
    function toHex32(passphrase: string): string;
    let NICEWARE_32_BYTE_WORD_COUNT: number;
    let BIP39_32_BYTE_WORD_COUNT: number;
}
export namespace random {
    function uniform(n: number): number;
    function uniform_01(): number;
}
```