### PR TITLE
feat: add ed25519 HTTPS signature creation & verification

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -243,7 +243,7 @@ Signs the message using the secret key and returns a signature.
 | Param | Type | Description |
 | --- | --- | --- |
 | keyId | <code>string</code> | an opaque string that the server can use to look up the component they need to validate the signature |
-| secretKey | <code>string</code> | secret key to sign the message |
+| secretKey | <code>string</code> | hex encoded secret key to sign the message |
 | headers | [<code>HeaderLike</code>](#HeaderLike) | headers containing the properties to sign |
 
 <a name="ed25519Verify"></a>
@@ -257,7 +257,7 @@ Verifies the signature for the message and returns true if verification succeede
 
 | Param | Type | Description |
 | --- | --- | --- |
-| publicKey | <code>string</code> | public key to verify the signature |
+| publicKey | <code>string</code> | hex encoded public key to verify the signature |
 | headers | [<code>HeaderLike</code>](#HeaderLike) | headers containing the signature for verification |
 
 <a name="HeaderLike"></a>

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,11 +40,11 @@ Returns a nacl.sign keypair object:
 <dt><a href="#hexToUint8">hexToUint8([hex])</a> ⇒ <code>Uint8Array</code></dt>
 <dd><p>Converts hex string to a Uint8Array.</p>
 </dd>
-<dt><a href="#ed25519Sign">ed25519Sign(keyId, secretKey, headers)</a> ⇒ <code>string</code></dt>
+<dt><a href="#ed25519HttpSign">ed25519HttpSign(keyId, secretKey, headers)</a> ⇒ <code>string</code></dt>
 <dd><p>Uses Ed25519: a public-key signature system <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a> <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a>
 Signs the message using the secret key and returns a signature.</p>
 </dd>
-<dt><a href="#ed25519Verify">ed25519Verify(publicKey, headers)</a> ⇒ <code>boolean</code></dt>
+<dt><a href="#ed25519HttpVerify">ed25519HttpVerify(publicKey, headers)</a> ⇒ <code>Object</code></dt>
 <dd><p>Uses Ed25519: a public-key signature system <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a> <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a>
 Verifies the signature for the message and returns true if verification succeeded or false if it failed.</p>
 </dd>
@@ -231,9 +231,9 @@ Converts hex string to a Uint8Array.
 | --- | --- | --- |
 | [hex] | <code>string</code> | Hex string to convert; defaults to ''. |
 
-<a name="ed25519Sign"></a>
+<a name="ed25519HttpSign"></a>
 
-## ed25519Sign(keyId, secretKey, headers) ⇒ <code>string</code>
+## ed25519HttpSign(keyId, secretKey, headers) ⇒ <code>string</code>
 Uses Ed25519: a public-key signature system [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/) [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
 Signs the message using the secret key and returns a signature.
 
@@ -246,9 +246,9 @@ Signs the message using the secret key and returns a signature.
 | secretKey | <code>string</code> | hex encoded secret key to sign the message |
 | headers | [<code>HeaderLike</code>](#HeaderLike) | headers containing the properties to sign |
 
-<a name="ed25519Verify"></a>
+<a name="ed25519HttpVerify"></a>
 
-## ed25519Verify(publicKey, headers) ⇒ <code>boolean</code>
+## ed25519HttpVerify(publicKey, headers) ⇒ <code>Object</code>
 Uses Ed25519: a public-key signature system [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/) [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
 Verifies the signature for the message and returns true if verification succeeded or false if it failed.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,6 +40,22 @@ Returns a nacl.sign keypair object:
 <dt><a href="#hexToUint8">hexToUint8([hex])</a> ⇒ <code>Uint8Array</code></dt>
 <dd><p>Converts hex string to a Uint8Array.</p>
 </dd>
+<dt><a href="#ed25519Sign">ed25519Sign(keyId, secretKey, headers)</a> ⇒ <code>string</code></dt>
+<dd><p>Uses Ed25519: a public-key signature system <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a> <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a>
+Signs the message using the secret key and returns a signature.</p>
+</dd>
+<dt><a href="#ed25519Verify">ed25519Verify(publicKey, headers)</a> ⇒ <code>boolean</code></dt>
+<dd><p>Uses Ed25519: a public-key signature system <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a> <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a>
+Verifies the signature for the message and returns true if verification succeeded or false if it failed.</p>
+</dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#HeaderLike">HeaderLike</a> : <code>Object.&lt;string, (string|Array.&lt;string&gt;|undefined)&gt;</code></dt>
+<dd><p>A dictionary of header values, i.e &#39;{ &#39;header-name&#39;: &#39;header-value&#39; }&#39;</p>
+</dd>
 </dl>
 
 <a name="passphrase"></a>
@@ -215,3 +231,38 @@ Converts hex string to a Uint8Array.
 | --- | --- | --- |
 | [hex] | <code>string</code> | Hex string to convert; defaults to ''. |
 
+<a name="ed25519Sign"></a>
+
+## ed25519Sign(keyId, secretKey, headers) ⇒ <code>string</code>
+Uses Ed25519: a public-key signature system [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/) [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
+Signs the message using the secret key and returns a signature.
+
+**Kind**: global function  
+**See**: {nacl.sign.detached}  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyId | <code>string</code> | an opaque string that the server can use to look up the component they need to validate the signature |
+| secretKey | <code>string</code> | secret key to sign the message |
+| headers | [<code>HeaderLike</code>](#HeaderLike) | headers containing the properties to sign |
+
+<a name="ed25519Verify"></a>
+
+## ed25519Verify(publicKey, headers) ⇒ <code>boolean</code>
+Uses Ed25519: a public-key signature system [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/) [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
+Verifies the signature for the message and returns true if verification succeeded or false if it failed.
+
+**Kind**: global function  
+**See**: {nacl.sign.detached.verify}  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| publicKey | <code>string</code> | public key to verify the signature |
+| headers | [<code>HeaderLike</code>](#HeaderLike) | headers containing the signature for verification |
+
+<a name="HeaderLike"></a>
+
+## HeaderLike : <code>Object.&lt;string, (string\|Array.&lt;string&gt;\|undefined)&gt;</code>
+A dictionary of header values, i.e '{ 'header-name': 'header-value' }'
+
+**Kind**: global typedef  

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,20 +41,22 @@ Returns a nacl.sign keypair object:
 <dd><p>Converts hex string to a Uint8Array.</p>
 </dd>
 <dt><a href="#ed25519HttpSign">ed25519HttpSign(keyId, secretKey, headers)</a> ⇒ <code>string</code></dt>
-<dd><p>Uses Ed25519: a public-key signature system <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a> <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a>
-Signs the message using the secret key and returns a signature.</p>
+<dd><p>Uses Ed25519, a public-key signature system: <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a></p>
+<p>Spec: <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a></p>
+<p>Signs the message using the secret key and returns a signature.</p>
 </dd>
 <dt><a href="#ed25519HttpVerify">ed25519HttpVerify(publicKey, headers)</a> ⇒ <code>Object</code></dt>
-<dd><p>Uses Ed25519: a public-key signature system <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a> <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a>
-Verifies the signature for the message and returns true if verification succeeded or false if it failed.</p>
+<dd><p>Uses Ed25519, a public-key signature system: <a href="https://ed25519.cr.yp.to/">https://ed25519.cr.yp.to/</a></p>
+<p>Spec: <a href="https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12">https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12</a></p>
+<p>Verifies the signature for the message and returns parsed fields from the signature.</p>
 </dd>
 </dl>
 
 ## Typedefs
 
 <dl>
-<dt><a href="#HeaderLike">HeaderLike</a> : <code>Object.&lt;string, (string|Array.&lt;string&gt;|undefined)&gt;</code></dt>
-<dd><p>A dictionary of header values, i.e &#39;{ &#39;header-name&#39;: &#39;header-value&#39; }&#39;</p>
+<dt><a href="#Dictionary">Dictionary</a> : <code>Object.&lt;string, (string|Array.&lt;string&gt;|undefined)&gt;</code></dt>
+<dd><p>A dictionary of values, commonly used for objects i.e &#39;{ &#39;header-name&#39;: &#39;header-value&#39; }&#39;</p>
 </dd>
 </dl>
 
@@ -234,7 +236,10 @@ Converts hex string to a Uint8Array.
 <a name="ed25519HttpSign"></a>
 
 ## ed25519HttpSign(keyId, secretKey, headers) ⇒ <code>string</code>
-Uses Ed25519: a public-key signature system [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/) [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
+Uses Ed25519, a public-key signature system: [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/)
+
+Spec: [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
+
 Signs the message using the secret key and returns a signature.
 
 **Kind**: global function  
@@ -242,27 +247,30 @@ Signs the message using the secret key and returns a signature.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| keyId | <code>string</code> | an opaque string that the server can use to look up the component they need to validate the signature |
-| secretKey | <code>string</code> | hex encoded secret key to sign the message |
-| headers | [<code>HeaderLike</code>](#HeaderLike) | headers containing the properties to sign |
+| keyId | <code>string</code> | an opaque string that the server can use to look up the component they need to validate the signature. |
+| secretKey | <code>string</code> | hex encoded secret key to sign the message. |
+| headers | [<code>Dictionary</code>](#Dictionary) | headers containing the properties to sign. |
 
 <a name="ed25519HttpVerify"></a>
 
 ## ed25519HttpVerify(publicKey, headers) ⇒ <code>Object</code>
-Uses Ed25519: a public-key signature system [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/) [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
-Verifies the signature for the message and returns true if verification succeeded or false if it failed.
+Uses Ed25519, a public-key signature system: [https://ed25519.cr.yp.to/](https://ed25519.cr.yp.to/)
+
+Spec: [https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12)
+
+Verifies the signature for the message and returns parsed fields from the signature.
 
 **Kind**: global function  
 **See**: {nacl.sign.detached.verify}  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| publicKey | <code>string</code> | hex encoded public key to verify the signature |
-| headers | [<code>HeaderLike</code>](#HeaderLike) | headers containing the signature for verification |
+| publicKey | <code>string</code> | hex encoded public key to verify the signature. |
+| headers | [<code>Dictionary</code>](#Dictionary) | headers containing the signature for verification. |
 
-<a name="HeaderLike"></a>
+<a name="Dictionary"></a>
 
-## HeaderLike : <code>Object.&lt;string, (string\|Array.&lt;string&gt;\|undefined)&gt;</code>
-A dictionary of header values, i.e '{ 'header-name': 'header-value' }'
+## Dictionary : <code>Object.&lt;string, (string\|Array.&lt;string&gt;\|undefined)&gt;</code>
+A dictionary of values, commonly used for objects i.e '{ 'header-name': 'header-value' }'
 
 **Kind**: global typedef  

--- a/index.js
+++ b/index.js
@@ -356,7 +356,7 @@ module.exports.random = {
  * @param {HeaderLike} headers - headers containing the properties to sign
  * @returns {string}
  */
-module.exports.ed25519Sign = function (keyId /* string */, secretKey /* string */, headers = {} /* dictionary */) {
+module.exports.ed25519HttpSign = function (keyId /* string */, secretKey /* string */, headers = {} /* dictionary */) {
   if (!secretKey) throw new Error('secret key is required')
   if (!keyId) throw new Error('key id is required')
   if (Object.keys(headers).length === 0) throw new Error('headers are required')
@@ -388,7 +388,7 @@ module.exports.ed25519Sign = function (keyId /* string */, secretKey /* string *
  * @param {HeaderLike} headers - headers containing the signature for verification
  * @returns {boolean}
  */
-module.exports.ed25519Verify = function (publicKey /* string */, headers = {} /* dictionary */) {
+module.exports.ed25519HttpVerify = function (publicKey /* string */, headers = {} /* dictionary */) {
   if (!publicKey) throw new Error('public key is required')
   if (!headers.signature) throw new Error('header signature is required')
 

--- a/index.js
+++ b/index.js
@@ -406,7 +406,7 @@ module.exports.ed25519HttpVerify = function (publicKey /* string */, headers = {
   if (!signedRequest.keyId) throw new Error('no keyId was parsed')
   if (!signedRequest.headers) throw new Error('no headers were parsed')
 
-  const signedRequestHeaders = signedRequest.headers.split(' ');
+  const signedRequestHeaders = signedRequest.headers.split(' ')
   const message = signedRequestHeaders.map(key => `${key}: ${headers[key]}`).join('\n')
   const verified = nacl.sign.detached.verify(
     Uint8Array.from(Buffer.from(message)),

--- a/index.js
+++ b/index.js
@@ -339,3 +339,67 @@ module.exports.random = {
     return s * Math.pow(2, (-64 - e))
   }
 }
+
+/**
+ * Utils for simple signing and verification of HTTPS requests
+ **/
+module.exports.https = {
+  /**
+   * Sign the `message` with the given `secretKey`.
+   *
+   * @method
+   * @param {any} headers - headers containing the properties to sign
+   * @param {string} keyId - an opaque string that the server can use to look up the component they need to validate the signature
+   * @param {string} secretKey - secret key to sign the message
+   * @returns {string}
+   */
+  ed25519Sign: function (headers /* any */, keyId /* string */, secretKey /* string */) {
+    if (!secretKey) throw new Error('secret key is required')
+    if (!keyId) throw new Error('key id is required')
+    if (JSON.stringify(headers) === '{}') throw new Error('headers are required')
+
+    const headerKeys = []
+    const message = Object.entries(headers)
+      .map(([key, value]) => {
+        headerKeys.push(key)
+        return `${key}: ${value}`
+      }).join('\n')
+
+    // Generate signature using the ed25519 algorithm.
+    const sign = nacl.sign.detached(
+      Uint8Array.from(Buffer.from(message)),
+      Uint8Array.from(Buffer.from(secretKey, 'hex'))
+    )
+
+    const signature = Buffer.from(sign).toString('base64')
+    return `keyId="${keyId}",algorithm="ed25519,headers="${headerKeys.join(' ')}",signature="${signature}"`
+  },
+
+  /**
+   * Verify the signed `message` with the given `publicKey`.
+   *
+   * @method
+   * @param {any} headers - headers containing the signature for verification
+   * @param {string} publicKey - public key to verify the signature
+   * @returns {boolean}
+   */
+  ed25519Verify: function (headers /* any */, publicKey /* string */) {
+    if (!publicKey) throw new Error('public key is required')
+    if (!headers.signature) throw new Error('signature is required')
+
+    const signedRequest = headers.signature.split(',').reduce((result, part) => {
+      const [key, value] = part.split('=')
+      result[key] = value.replace(/"/g, '') // remove quotes
+      return result
+    }, {})
+
+    const message = signedRequest.headers.split(' ').map(key => `${key}: ${headers[key]}`).join('\n')
+    const signature = Buffer.from(signedRequest.signature, 'base64')
+
+    return nacl.sign.detached.verify(
+      Uint8Array.from(Buffer.from(message)),
+      Uint8Array.from(Buffer.from(signature, 'base64')),
+      Uint8Array.from(Buffer.from(publicKey, 'hex'))
+    )
+  }
+}

--- a/index.js
+++ b/index.js
@@ -341,19 +341,22 @@ module.exports.random = {
 }
 
 /**
- * A dictionary of header values, i.e '{ 'header-name': 'header-value' }'
- * @typedef {Object.<string, (string | string[] | undefined)>} HeaderLike
+ * A dictionary of values, commonly used for objects i.e '{ 'header-name': 'header-value' }'
+ * @typedef {Object.<string, (string | string[] | undefined)>} Dictionary
  */
 
 /**
- * Uses Ed25519: a public-key signature system: {@link https://ed25519.cr.yp.to/} {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}.
+ * Uses Ed25519, a public-key signature system: {@link https://ed25519.cr.yp.to/}
+ *
+ * Spec: {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}
+ *
  * Signs the message using the secret key and returns a signature.
- * @see {nacl.sign.detached}.
+ * @see {nacl.sign.detached}
  *
  * @method
  * @param {string} keyId - an opaque string that the server can use to look up the component they need to validate the signature.
  * @param {string} secretKey - hex encoded secret key to sign the message.
- * @param {HeaderLike} headers - headers containing the properties to sign.
+ * @param {Dictionary} headers - headers containing the properties to sign.
  * @returns {string}
  */
 module.exports.ed25519HttpSign = function (keyId /* string */, secretKey /* string */, headers = {} /* dictionary */) {
@@ -379,14 +382,17 @@ module.exports.ed25519HttpSign = function (keyId /* string */, secretKey /* stri
 }
 
 /**
- * Uses Ed25519: a public-key signature system: {@link https://ed25519.cr.yp.to/} {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}.
+ * Uses Ed25519, a public-key signature system: {@link https://ed25519.cr.yp.to/}
+ *
+ * Spec: {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}
+ *
  * Verifies the signature for the message and returns parsed fields from the signature.
- * @see {nacl.sign.detached.verify}.
+ * @see {nacl.sign.detached.verify}
  *
  * @method
  * @param {string} publicKey - hex encoded public key to verify the signature.
- * @param {HeaderLike} headers - headers containing the signature for verification.
- * @returns {{ algorithm: string, headers: string[], keyId: string, signature: string, verified: boolean }}.
+ * @param {Dictionary} headers - headers containing the signature for verification.
+ * @returns {{ algorithm: string, headers: string[], keyId: string, signature: string, verified: boolean }}
  */
 module.exports.ed25519HttpVerify = function (publicKey /* string */, headers = {} /* dictionary */) {
   if (!publicKey) throw new Error('public key is required')

--- a/index.js
+++ b/index.js
@@ -352,7 +352,7 @@ module.exports.random = {
  *
  * @method
  * @param {string} keyId - an opaque string that the server can use to look up the component they need to validate the signature
- * @param {string} secretKey - secret key to sign the message
+ * @param {string} secretKey - hex encoded secret key to sign the message
  * @param {HeaderLike} headers - headers containing the properties to sign
  * @returns {string}
  */
@@ -384,7 +384,7 @@ module.exports.ed25519Sign = function (keyId /* string */, secretKey /* string *
  * @see {nacl.sign.detached.verify}
  *
  * @method
- * @param {string} publicKey - public key to verify the signature
+ * @param {string} publicKey - hex encoded public key to verify the signature
  * @param {HeaderLike} headers - headers containing the signature for verification
  * @returns {boolean}
  */

--- a/index.js
+++ b/index.js
@@ -372,7 +372,7 @@ module.exports.https = {
     )
 
     const signature = Buffer.from(sign).toString('base64')
-    return `keyId="${keyId}",algorithm="ed25519,headers="${headerKeys.join(' ')}",signature="${signature}"`
+    return `keyId="${keyId}",algorithm="ed25519",headers="${headerKeys.join(' ')}",signature="${signature}"`
   },
 
   /**
@@ -394,11 +394,9 @@ module.exports.https = {
     }, {})
 
     const message = signedRequest.headers.split(' ').map(key => `${key}: ${headers[key]}`).join('\n')
-    const signature = Buffer.from(signedRequest.signature, 'base64')
-
     return nacl.sign.detached.verify(
       Uint8Array.from(Buffer.from(message)),
-      Uint8Array.from(Buffer.from(signature, 'base64')),
+      Uint8Array.from(Buffer.from(signedRequest.signature, 'base64')),
       Uint8Array.from(Buffer.from(publicKey, 'hex'))
     )
   }

--- a/index.js
+++ b/index.js
@@ -346,14 +346,14 @@ module.exports.random = {
  */
 
 /**
- * Uses Ed25519: a public-key signature system {@link https://ed25519.cr.yp.to/} {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}
+ * Uses Ed25519: a public-key signature system: {@link https://ed25519.cr.yp.to/} {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}.
  * Signs the message using the secret key and returns a signature.
- * @see {nacl.sign.detached}
+ * @see {nacl.sign.detached}.
  *
  * @method
- * @param {string} keyId - an opaque string that the server can use to look up the component they need to validate the signature
- * @param {string} secretKey - hex encoded secret key to sign the message
- * @param {HeaderLike} headers - headers containing the properties to sign
+ * @param {string} keyId - an opaque string that the server can use to look up the component they need to validate the signature.
+ * @param {string} secretKey - hex encoded secret key to sign the message.
+ * @param {HeaderLike} headers - headers containing the properties to sign.
  * @returns {string}
  */
 module.exports.ed25519HttpSign = function (keyId /* string */, secretKey /* string */, headers = {} /* dictionary */) {
@@ -379,14 +379,14 @@ module.exports.ed25519HttpSign = function (keyId /* string */, secretKey /* stri
 }
 
 /**
- * Uses Ed25519: a public-key signature system {@link https://ed25519.cr.yp.to/} {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}
- * Verifies the signature for the message and returns true if verification succeeded or false if it failed.
- * @see {nacl.sign.detached.verify}
+ * Uses Ed25519: a public-key signature system: {@link https://ed25519.cr.yp.to/} {@link https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12}.
+ * Verifies the signature for the message and returns parsed fields from the signature.
+ * @see {nacl.sign.detached.verify}.
  *
  * @method
- * @param {string} publicKey - hex encoded public key to verify the signature
- * @param {HeaderLike} headers - headers containing the signature for verification
- * @returns {{ algorithm: string, headers: string[], keyId: string, signature: string, verified: boolean }}
+ * @param {string} publicKey - hex encoded public key to verify the signature.
+ * @param {HeaderLike} headers - headers containing the signature for verification.
+ * @returns {{ algorithm: string, headers: string[], keyId: string, signature: string, verified: boolean }}.
  */
 module.exports.ed25519HttpVerify = function (publicKey /* string */, headers = {} /* dictionary */) {
   if (!publicKey) throw new Error('public key is required')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brave-crypto",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brave-crypto",
-      "version": "0.4.0",
+      "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "bip39": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-crypto",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "Crypto utils for Brave Browser",
   "keywords": [
     "nacl",

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -164,11 +164,11 @@ test('signing', (t) => {
   const headers = { foo: 'bar', fizz: 'buzz' }
   t.plan(6)
   
-  let signature = crypto.ed25519HttpSign('test-key-ed25519', pair.secretKey, headers);
+  let signature = crypto.ed25519HttpSign('test-key-ed25519', pair.secretKey, headers)
   t.equal(signature, goodSignature)
   
   // Incorrect header
-  signature = crypto.ed25519HttpSign('test-key-ed25519', pair.secretKey, { ...headers, fizz: 'fizz' });
+  signature = crypto.ed25519HttpSign('test-key-ed25519', pair.secretKey, { ...headers, fizz: 'fizz' })
   t.notEqual(signature, goodSignature)
   
   // No headers
@@ -184,8 +184,8 @@ test('signing', (t) => {
     'primary', 
     '96aa9ec42242a9a62196281045705196a64e12b15e9160bbb630e38385b82700e7876fd5cc3a228dad634816f4ec4b80a258b2a552467e5d26f30003211bc45d', 
     { foo: 'bar' }
-  );
-  t.equal(original, 'keyId="primary",algorithm="ed25519",headers="foo",signature="RbGSX1MttcKCpCkq9nsPGkdJGUZsAU+0TpiXJYkwde+0ZwxEp9dXO3v17DwyGLXjv385253RdGI7URbrI7J6DQ=="');
+  )
+  t.equal(original, 'keyId="primary",algorithm="ed25519",headers="foo",signature="RbGSX1MttcKCpCkq9nsPGkdJGUZsAU+0TpiXJYkwde+0ZwxEp9dXO3v17DwyGLXjv385253RdGI7URbrI7J6DQ=="')
 })
 
 test('verification', (t) => {

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -152,3 +152,26 @@ test('key derivation', (t) => {
   t.deepEqual(nacl.sign.open(signed, key.publicKey), null, 'verification failure')
   t.throws(crypto.deriveSigningKeysFromSeed.bind(null, []), /Uint8Array/, 'error when input is not a Uint8Array')
 })
+
+test('signing', (t) => {
+  t.plan(1)
+  const signature = crypto.https.ed25519Sign({ foo: 'bar' },
+    'primary',
+    '96aa9ec42242a9a62196281045705196a64e12b15e9160bbb630e38385b82700e7876fd5cc3a228dad634816f4ec4b80a258b2a552467e5d26f30003211bc45d',
+  );
+  
+  t.equal(signature, 'keyId="primary",algorithm="ed25519",headers="foo",signature="RbGSX1MttcKCpCkq9nsPGkdJGUZsAU+0TpiXJYkwde+0ZwxEp9dXO3v17DwyGLXjv385253RdGI7URbrI7J6DQ=="')
+})
+
+test('verification', (t) => {
+  t.plan(1)
+  const verified = crypto.https.ed25519Verify(
+    {
+      foo: 'bar',
+      signature: 'keyId="primary",algorithm="ed25519",headers="foo",signature="RbGSX1MttcKCpCkq9nsPGkdJGUZsAU+0TpiXJYkwde+0ZwxEp9dXO3v17DwyGLXjv385253RdGI7URbrI7J6DQ=="'
+    },
+    'e7876fd5cc3a228dad634816f4ec4b80a258b2a552467e5d26f30003211bc45d'
+  )
+  
+  t.equal(verified, true)
+})

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -164,58 +164,58 @@ test('signing', (t) => {
   const headers = { foo: 'bar', fizz: 'buzz' }
   t.plan(5)
   
-  let signature = crypto.ed25519Sign('test-key-ed25519', pair.secretKey, headers);
+  let signature = crypto.ed25519HttpSign('test-key-ed25519', pair.secretKey, headers);
   t.equal(signature, goodSignature)
   
   // Incorrect header
-  signature = crypto.ed25519Sign('test-key-ed25519', pair.secretKey, { ...headers, fizz: 'fizz' });
+  signature = crypto.ed25519HttpSign('test-key-ed25519', pair.secretKey, { ...headers, fizz: 'fizz' });
   t.notEqual(signature, goodSignature)
   
   // No headers
-  t.throws(crypto.ed25519Sign.bind('test-key-ed25519', pair.secretKey), 'headers are required')
+  t.throws(crypto.ed25519HttpSign.bind('test-key-ed25519', pair.secretKey), 'headers are required')
   
   // No Secret Key
-  t.throws(crypto.ed25519Sign.bind('test-key-ed25519', pair.secretKey, headers), 'secret key is required')
+  t.throws(crypto.ed25519HttpSign.bind('test-key-ed25519', pair.secretKey, headers), 'secret key is required')
   
   // No Key ID
-  t.throws(crypto.ed25519Sign.bind(null, pair.secretKey, headers), 'key ID is required')
+  t.throws(crypto.ed25519HttpSign.bind(null, pair.secretKey, headers), 'key ID is required')
 })
 
 test('verification', (t) => {
   t.plan(8)
   const headers = { foo: 'bar', fizz: 'buzz', signature: goodSignature }
-  let verified = crypto.ed25519Verify(pair.publicKey, headers)
+  let verified = crypto.ed25519HttpVerify(pair.publicKey, headers)
   t.equal(verified, true)
   
   // Miss a byte
   let testKey = pair.publicKey;
-  t.throws(crypto.ed25519Verify.bind(testKey.slice(0, 2), headers), 'bad public key size')
+  t.throws(crypto.ed25519HttpVerify.bind(testKey.slice(0, 2), headers), 'bad public key size')
   
   // Modify a byte
   testKey = Uint8Array.from(pair.publicKey);
   testKey[0] = 0;
-  verified = crypto.ed25519Verify(testKey, headers)
+  verified = crypto.ed25519HttpVerify(testKey, headers)
   t.equal(verified, false)
   
   // Miss a header
   let bad = { foo: 'bar', signature: goodSignature }
-  verified = crypto.ed25519Verify(testKey, bad)
+  verified = crypto.ed25519HttpVerify(testKey, bad)
   t.equal(verified, false)
   
   // Missing part of the signature
   bad = { ...headers }
   bad.signature = bad.signature.slice(25, goodSignature.length)
   t.equal(bad.signature, 'algorithm="ed25519",headers="foo fizz",signature="lAGT9Bhde3sJp8Z1NTxmViJtG1PSoYnXV9he82z1iu//KXmCrjKYe1JOU34memKIdlxG1yJoeS2hxANRvalrBw=="')
-  verified = crypto.ed25519Verify(testKey, bad)
+  verified = crypto.ed25519HttpVerify(testKey, bad)
   t.equal(verified, false)
   
   // Missing signature
   bad = { ...headers }
   delete bad.signature
-  t.throws(crypto.ed25519Verify.bind(pair.publicKey, bad), 'header signature is required')
+  t.throws(crypto.ed25519HttpVerify.bind(pair.publicKey, bad), 'header signature is required')
   
   // Missing equal
   const eq = { ...headers }
   eq.signature = 'keyId="test-key-ed25519",algorithm="ed25519",headers="foo fizz",signature"lAGT9Bhde3sJp8Z1NTxmViJtG1PSoYnXV9he82z1iu//KXmCrjKYe1JOU34memKIdlxG1yJoeS2hxANRvalrBw=="'
-  t.throws(crypto.ed25519Verify.bind(pair.publicKey, bad), 'no signature was parsed')
+  t.throws(crypto.ed25519HttpVerify.bind(pair.publicKey, bad), 'no signature was parsed')
 })

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -182,14 +182,14 @@ test('signing', (t) => {
 })
 
 test('verification', (t) => {
-  t.plan(7)
+  t.plan(8)
   const headers = { foo: 'bar', fizz: 'buzz', signature: goodSignature }
   let verified = crypto.ed25519Verify(pair.publicKey, headers)
   t.equal(verified, true)
   
   // Miss a byte
   let testKey = pair.publicKey;
-  t.throws(crypto.ed25519Verify.bind(testKey.slice(1, 2), headers), 'header signature is required')
+  t.throws(crypto.ed25519Verify.bind(testKey.slice(0, 2), headers), 'bad public key size')
   
   // Modify a byte
   testKey = Uint8Array.from(pair.publicKey);
@@ -212,5 +212,10 @@ test('verification', (t) => {
   // Missing signature
   bad = { ...headers }
   delete bad.signature
-  t.throws(crypto.ed25519Verify.bind(pair.publicKey, headers), 'header signature is required')
+  t.throws(crypto.ed25519Verify.bind(pair.publicKey, bad), 'header signature is required')
+  
+  // Missing equal
+  const eq = { ...headers }
+  eq.signature = 'keyId="test-key-ed25519",algorithm="ed25519",headers="foo fizz",signature"lAGT9Bhde3sJp8Z1NTxmViJtG1PSoYnXV9he82z1iu//KXmCrjKYe1JOU34memKIdlxG1yJoeS2hxANRvalrBw=="'
+  t.throws(crypto.ed25519Verify.bind(pair.publicKey, bad), 'no signature was parsed')
 })

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -52,126 +52,64 @@ test('hmac', (t) => {
   t.throws(crypto.hmac.bind(null, new Uint8Array(), []), /Uint8Arrays/, 'errors if inputs are wrong type')
 })
 
-test('hkdf', (t) => {
-  // https://www.kullo.net/blog/hkdf-sha-512-test-vectors/
-  var results = [{
-    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
-    "salt"  : "000102030405060708090a0b0c",
-    "info"  : "f0f1f2f3f4f5f6f7f8f9",
-    "L"     : 42,
-    "OKM"   : "832390086cda71fb47625bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb"
-  }, {
-    "IKM"   : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
-    "salt"  : "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
-    "info"  : "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-    "L"     : 82,
-    "OKM"   : "ce6c97192805b346e6161e821ed165673b84f400a2b514b2fe23d84cd189ddf1b695b48cbd1c8388441137b3ce28f16aa64ba33ba466b24df6cfcb021ecff235f6a2056ce3af1de44d572097a8505d9e7a93"
-  }, {
-    "IKM"   : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
-    "salt"  : "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
-    "info"  : "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
-    "L"     : 64, // Same as above but truncated to a multiple of HMAC length.
-    "OKM"   : "ce6c97192805b346e6161e821ed165673b84f400a2b514b2fe23d84cd189ddf1b695b48cbd1c8388441137b3ce28f16aa64ba33ba466b24df6cfcb021ecff235"
-  }, {
-    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
-    "salt"  : "",
-    "info"  : "",
-    "L"     : 42,
-    "OKM"   : "f5fa02b18298a72a8c23898a8703472c6eb179dc204c03425c970e3b164bf90fff22d04836d0e2343bac"
-  }, {
-    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
-    "salt"  : "",
-    // "info"  : ...,       // This field intentionally blank.
-    "L"     : 42,
-    "OKM"   : "f5fa02b18298a72a8c23898a8703472c6eb179dc204c03425c970e3b164bf90fff22d04836d0e2343bac"
-  }, {
-    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b",
-    "salt"  : "000102030405060708090a0b0c",
-    "info"  : "f0f1f2f3f4f5f6f7f8f9",
-    "L"     : 42,
-    "OKM"   : "7413e8997e020610fbf6823f2ce14bff01875db1ca55f68cfcf3954dc8aff53559bd5e3028b080f7c068"
-  }, {
-    "IKM"   : "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
-    "info"  : "",
-    "L"     : 42,
-    "OKM"   : "1407d46013d98bc6decefcfee55f0f90b0c7f63d68eb1a80eaf07e953cfc0a3a5240a155d6e4daa965bb"
-  }]
-  t.plan(8)
-  results.forEach((result) => {
-    var hkdf = crypto.getHKDF(
-      fromHex(result['IKM']),
-      'info' in result && fromHex(result['info']),
-      result['L'],
-      fromHex(result['salt'])
-    )
-    t.equal(toHex(hkdf), result['OKM'])
-  })
-  t.throws(crypto.getHKDF.bind(null, new Uint8Array(1), new Uint8Array(), 16321), /Invalid extract length/, 'error when extract length is too long')
-})
-
-test('uint8ToHex', (t) => {
-  t.plan(8)
-  t.equal(toHex(new Uint8Array([])), '')
-  t.equal(toHex(new Uint8Array([0])), '00')
-  t.equal(toHex(new Uint8Array([0, 255])), '00ff')
-  t.equal(toHex(new Uint8Array([30, 1, 2, 3])), '1e010203')
-  const buf = new ArrayBuffer(6)
-  for (let i = 0; i < 6; i++) {
-    new Uint8Array(buf)[i] = [42, 30, 1, 2, 3, 73][i]
-  }
-  t.equal(toHex(new Uint8Array(buf, 1, 4)), '1e010203')
-  t.equal(toHex(Buffer.from([30, 1, 2, 3])), '1e010203')
-  t.equal(toHex(Buffer.alloc(3)), '000000')
-  t.throws(toHex.bind(null, 'foo'), /Uint8Array/, 'errors if inputs are wrong type')
-})
-
-test('hexToUint8', (t) => {
-  t.plan(9)
-  t.deepEqual(fromHex('00'), {0: 0})
-  t.deepEqual(fromHex('1'), {0: 1})
-  t.deepEqual(fromHex(''), {})
-  t.deepEqual(fromHex('00ff'), {0: 0, 1: 255})
-  t.deepEqual(fromHex('1e010203'), {0: 30, 1: 1, 2: 2, 3: 3})
-  t.deepEqual(fromHex('1E010203'), {0: 30, 1: 1, 2: 2, 3: 3})
-  t.throws(fromHex.bind(null, new Uint8Array(3)), /must be a string/, 'errors if inputs are wrong type')
-  t.throws(fromHex.bind(null, '1e010203g'), /must be hex/, 'errors if input is not hex')
-  t.throws(fromHex.bind(null, '0x1ffb78'), /without the 0x prefix/, 'errors if input has 0x prefix')
-})
-
-test('key derivation', (t) => {
-  const HKDF_SALT = new Uint8Array([72, 203, 156, 43, 64, 229, 225, 127, 214, 158, 50, 29, 130, 186, 182, 207, 6, 108, 47, 254, 245, 71, 198, 109, 44, 108, 32, 193, 221, 126, 119, 143, 112, 113, 87, 184, 239, 231, 230, 234, 28, 135, 54, 42, 9, 243, 39, 30, 179, 147, 194, 211, 212, 239, 225, 52, 192, 219, 145, 40, 95, 19, 142, 98])
-  t.plan(5)
-  const key = crypto.deriveSigningKeysFromSeed(fromHex("5bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb"), HKDF_SALT)
-  t.equal('f58ca446f0c33ee7e8e9874466da442b2e764afd77ad46034bdff9e01f9b87d4', toHex(key.publicKey), 'gets pub key')
-  t.equal('b5abda6940984c5153a2ba3653f047f98dfb19e39c3e02f07c8bbb0bd8e8872ef58ca446f0c33ee7e8e9874466da442b2e764afd77ad46034bdff9e01f9b87d4', toHex(key.secretKey), 'gets priv key')
-  const message = Buffer.from('€ 123 ッッッ　あ')
-  const signed = nacl.sign(message, key.secretKey)
-  const opened = Buffer.from(nacl.sign.open(signed, key.publicKey))
-  t.deepEqual(opened, message, 'verification success')
-  signed[0] = 255
-  t.deepEqual(nacl.sign.open(signed, key.publicKey), null, 'verification failure')
-  t.throws(crypto.deriveSigningKeysFromSeed.bind(null, []), /Uint8Array/, 'error when input is not a Uint8Array')
-})
+const pair = nacl.sign.keyPair.fromSecretKey(
+  Uint8Array.from(
+    Buffer.from('9f8362f87a484a954e6e740c5b4c0e84229139a20aa8ab56ff66586f6a7d29c526b40b8f93fff3d897112f7ebc582b232dbd72517d082fe83cfb30ddce43d1bb', 'hex')
+  )
+)
+const goodSignature = 'keyId="test-key-ed25519",algorithm="ed25519",headers="foo fizz",signature="lAGT9Bhde3sJp8Z1NTxmViJtG1PSoYnXV9he82z1iu//KXmCrjKYe1JOU34memKIdlxG1yJoeS2hxANRvalrBw=="'
 
 test('signing', (t) => {
-  t.plan(1)
-  const signature = crypto.https.ed25519Sign({ foo: 'bar' },
-    'primary',
-    '96aa9ec42242a9a62196281045705196a64e12b15e9160bbb630e38385b82700e7876fd5cc3a228dad634816f4ec4b80a258b2a552467e5d26f30003211bc45d',
-  );
+  const headers = { foo: 'bar', fizz: 'buzz' }
+  t.plan(5)
+
+  let signature = crypto.ed25519Sign('test-key-ed25519', pair.secretKey, headers);
+  t.equal(signature, goodSignature)
   
-  t.equal(signature, 'keyId="primary",algorithm="ed25519",headers="foo",signature="RbGSX1MttcKCpCkq9nsPGkdJGUZsAU+0TpiXJYkwde+0ZwxEp9dXO3v17DwyGLXjv385253RdGI7URbrI7J6DQ=="')
+  // Incorrect header
+  signature = crypto.ed25519Sign('test-key-ed25519', pair.secretKey, { ...headers, fizz: 'fizz' });
+  t.notEqual(signature, goodSignature)
+  
+  // No headers
+  t.throws(crypto.ed25519Sign.bind('test-key-ed25519', pair.secretKey), 'headers are required')
+  
+  // No Secret Key
+  t.throws(crypto.ed25519Sign.bind('test-key-ed25519', pair.secretKey, headers), 'secret key is required')
+  
+  // No Key ID
+  t.throws(crypto.ed25519Sign.bind(null, pair.secretKey, headers), 'key ID is required')
 })
 
 test('verification', (t) => {
-  t.plan(1)
-  const verified = crypto.https.ed25519Verify(
-    {
-      foo: 'bar',
-      signature: 'keyId="primary",algorithm="ed25519",headers="foo",signature="RbGSX1MttcKCpCkq9nsPGkdJGUZsAU+0TpiXJYkwde+0ZwxEp9dXO3v17DwyGLXjv385253RdGI7URbrI7J6DQ=="'
-    },
-    'e7876fd5cc3a228dad634816f4ec4b80a258b2a552467e5d26f30003211bc45d'
-  )
-  
+  t.plan(7)
+  const headers = { foo: 'bar', fizz: 'buzz', signature: goodSignature }
+  let verified = crypto.ed25519Verify(pair.publicKey, headers)
   t.equal(verified, true)
+  
+  // Miss a byte
+  let testKey = pair.publicKey;
+  t.throws(crypto.ed25519Verify.bind(testKey.slice(1, 2), headers), 'header signature is required')
+  
+  // Modify a byte
+  testKey = Uint8Array.from(pair.publicKey);
+  testKey[0] = 0;
+  verified = crypto.ed25519Verify(testKey, headers)
+  t.equal(verified, false)
+  
+  // Miss a header
+  let bad = { foo: 'bar', signature: goodSignature }
+  verified = crypto.ed25519Verify(testKey, bad)
+  t.equal(verified, false)
+  
+  // Missing part of the signature
+  bad = { ...headers }
+  bad.signature = bad.signature.slice(25, goodSignature.length)
+  t.equal(bad.signature, 'algorithm="ed25519",headers="foo fizz",signature="lAGT9Bhde3sJp8Z1NTxmViJtG1PSoYnXV9he82z1iu//KXmCrjKYe1JOU34memKIdlxG1yJoeS2hxANRvalrBw=="')
+  verified = crypto.ed25519Verify(testKey, bad)
+  t.equal(verified, false)
+  
+  // Missing signature
+  bad = { ...headers }
+  delete bad.signature
+  t.throws(crypto.ed25519Verify.bind(pair.publicKey, headers), 'header signature is required')
 })

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -52,6 +52,107 @@ test('hmac', (t) => {
   t.throws(crypto.hmac.bind(null, new Uint8Array(), []), /Uint8Arrays/, 'errors if inputs are wrong type')
 })
 
+test('hkdf', (t) => {
+  // https://www.kullo.net/blog/hkdf-sha-512-test-vectors/
+  var results = [{
+    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+    "salt"  : "000102030405060708090a0b0c",
+    "info"  : "f0f1f2f3f4f5f6f7f8f9",
+    "L"     : 42,
+    "OKM"   : "832390086cda71fb47625bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb"
+  }, {
+    "IKM"   : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
+    "salt"  : "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+    "info"  : "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+    "L"     : 82,
+    "OKM"   : "ce6c97192805b346e6161e821ed165673b84f400a2b514b2fe23d84cd189ddf1b695b48cbd1c8388441137b3ce28f16aa64ba33ba466b24df6cfcb021ecff235f6a2056ce3af1de44d572097a8505d9e7a93"
+  }, {
+    "IKM"   : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
+    "salt"  : "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+    "info"  : "b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+    "L"     : 64, // Same as above but truncated to a multiple of HMAC length.
+    "OKM"   : "ce6c97192805b346e6161e821ed165673b84f400a2b514b2fe23d84cd189ddf1b695b48cbd1c8388441137b3ce28f16aa64ba33ba466b24df6cfcb021ecff235"
+  }, {
+    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+    "salt"  : "",
+    "info"  : "",
+    "L"     : 42,
+    "OKM"   : "f5fa02b18298a72a8c23898a8703472c6eb179dc204c03425c970e3b164bf90fff22d04836d0e2343bac"
+  }, {
+    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+    "salt"  : "",
+    // "info"  : ...,       // This field intentionally blank.
+    "L"     : 42,
+    "OKM"   : "f5fa02b18298a72a8c23898a8703472c6eb179dc204c03425c970e3b164bf90fff22d04836d0e2343bac"
+  }, {
+    "IKM"   : "0b0b0b0b0b0b0b0b0b0b0b",
+    "salt"  : "000102030405060708090a0b0c",
+    "info"  : "f0f1f2f3f4f5f6f7f8f9",
+    "L"     : 42,
+    "OKM"   : "7413e8997e020610fbf6823f2ce14bff01875db1ca55f68cfcf3954dc8aff53559bd5e3028b080f7c068"
+  }, {
+    "IKM"   : "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
+    "info"  : "",
+    "L"     : 42,
+    "OKM"   : "1407d46013d98bc6decefcfee55f0f90b0c7f63d68eb1a80eaf07e953cfc0a3a5240a155d6e4daa965bb"
+  }]
+  t.plan(8)
+  results.forEach((result) => {
+    var hkdf = crypto.getHKDF(
+      fromHex(result['IKM']),
+      'info' in result && fromHex(result['info']),
+      result['L'],
+      fromHex(result['salt'])
+    )
+    t.equal(toHex(hkdf), result['OKM'])
+  })
+  t.throws(crypto.getHKDF.bind(null, new Uint8Array(1), new Uint8Array(), 16321), /Invalid extract length/, 'error when extract length is too long')
+})
+
+test('uint8ToHex', (t) => {
+  t.plan(8)
+  t.equal(toHex(new Uint8Array([])), '')
+  t.equal(toHex(new Uint8Array([0])), '00')
+  t.equal(toHex(new Uint8Array([0, 255])), '00ff')
+  t.equal(toHex(new Uint8Array([30, 1, 2, 3])), '1e010203')
+  const buf = new ArrayBuffer(6)
+  for (let i = 0; i < 6; i++) {
+    new Uint8Array(buf)[i] = [42, 30, 1, 2, 3, 73][i]
+  }
+  t.equal(toHex(new Uint8Array(buf, 1, 4)), '1e010203')
+  t.equal(toHex(Buffer.from([30, 1, 2, 3])), '1e010203')
+  t.equal(toHex(Buffer.alloc(3)), '000000')
+  t.throws(toHex.bind(null, 'foo'), /Uint8Array/, 'errors if inputs are wrong type')
+})
+
+test('hexToUint8', (t) => {
+  t.plan(9)
+  t.deepEqual(fromHex('00'), {0: 0})
+  t.deepEqual(fromHex('1'), {0: 1})
+  t.deepEqual(fromHex(''), {})
+  t.deepEqual(fromHex('00ff'), {0: 0, 1: 255})
+  t.deepEqual(fromHex('1e010203'), {0: 30, 1: 1, 2: 2, 3: 3})
+  t.deepEqual(fromHex('1E010203'), {0: 30, 1: 1, 2: 2, 3: 3})
+  t.throws(fromHex.bind(null, new Uint8Array(3)), /must be a string/, 'errors if inputs are wrong type')
+  t.throws(fromHex.bind(null, '1e010203g'), /must be hex/, 'errors if input is not hex')
+  t.throws(fromHex.bind(null, '0x1ffb78'), /without the 0x prefix/, 'errors if input has 0x prefix')
+})
+
+test('key derivation', (t) => {
+  const HKDF_SALT = new Uint8Array([72, 203, 156, 43, 64, 229, 225, 127, 214, 158, 50, 29, 130, 186, 182, 207, 6, 108, 47, 254, 245, 71, 198, 109, 44, 108, 32, 193, 221, 126, 119, 143, 112, 113, 87, 184, 239, 231, 230, 234, 28, 135, 54, 42, 9, 243, 39, 30, 179, 147, 194, 211, 212, 239, 225, 52, 192, 219, 145, 40, 95, 19, 142, 98])
+  t.plan(5)
+  const key = crypto.deriveSigningKeysFromSeed(fromHex("5bb5ceb168e4c8e26a1a16ed34d9fc7fe92c1481579338da362cb8d9f925d7cb"), HKDF_SALT)
+  t.equal('f58ca446f0c33ee7e8e9874466da442b2e764afd77ad46034bdff9e01f9b87d4', toHex(key.publicKey), 'gets pub key')
+  t.equal('b5abda6940984c5153a2ba3653f047f98dfb19e39c3e02f07c8bbb0bd8e8872ef58ca446f0c33ee7e8e9874466da442b2e764afd77ad46034bdff9e01f9b87d4', toHex(key.secretKey), 'gets priv key')
+  const message = Buffer.from('€ 123 ッッッ　あ')
+  const signed = nacl.sign(message, key.secretKey)
+  const opened = Buffer.from(nacl.sign.open(signed, key.publicKey))
+  t.deepEqual(opened, message, 'verification success')
+  signed[0] = 255
+  t.deepEqual(nacl.sign.open(signed, key.publicKey), null, 'verification failure')
+  t.throws(crypto.deriveSigningKeysFromSeed.bind(null, []), /Uint8Array/, 'error when input is not a Uint8Array')
+})
+
 const pair = nacl.sign.keyPair.fromSecretKey(
   Uint8Array.from(
     Buffer.from('9f8362f87a484a954e6e740c5b4c0e84229139a20aa8ab56ff66586f6a7d29c526b40b8f93fff3d897112f7ebc582b232dbd72517d082fe83cfb30ddce43d1bb', 'hex')
@@ -62,7 +163,7 @@ const goodSignature = 'keyId="test-key-ed25519",algorithm="ed25519",headers="foo
 test('signing', (t) => {
   const headers = { foo: 'bar', fizz: 'buzz' }
   t.plan(5)
-
+  
   let signature = crypto.ed25519Sign('test-key-ed25519', pair.secretKey, headers);
   t.equal(signature, goodSignature)
   

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "declaration": true,
     "emitDeclarationOnly": true,
   },
-  "include": ["*.js", "**/*.ts"],
+  "include": ["index.js", "random-lib.js", "**/*.ts"],
 }


### PR DESCRIPTION
The library found https://www.npmjs.com/package/http-request-signature no longer meets the needs of the ads team, as it appears unmaintained and the dependencies pull in a binary blob.

```
dependencies:
http-request-signature 0.0.5
└─┬ debugnyan 2.0.2
  └─┬ bunyan 1.8.15
    └── dtrace-provider 0.8.8
```

This PR implements the logic necessary for ads-serve to effectively verify HTTP signature requests from ledger service